### PR TITLE
Fix v7 build for non-amd64 arches

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,6 +7,11 @@ description: |
   Elasticsearch, Graphite, InfluxDB, OpenTSB, Prometheus, and Hosted Metrics.
 confinement: strict
 grade: stable
+architectures:
+  - build-on: s390x
+  - build-on: ppc64el
+  - build-on: arm64
+  - build-on: amd64
 
 apps:
   grafana:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -55,7 +55,9 @@ parts:
     source-tag: v${SNAPCRAFT_PROJECT_VERSION}
     nodejs-version: '12.18.0'
     nodejs-package-manager: yarn
+    build-packages: [python-minimal,python-dev]
     override-build: |
+      export PYTHON=/usr/bin/python2
       export PATH=${SNAPCRAFT_PART_BUILD}/../npm/bin:$PATH
       yarn install --pure-lockfile --no-progress
       ${SNAPCRAFT_PART_BUILD}/node_modules/.bin/grunt build


### PR DESCRIPTION
This fixes the build for non-amd64 arches. it was failing because it was trying to download binary assets that don't exist for these other arches, and then it fell back on building it locally, but missed the dependencies.

That being said, it still won't work for armhf because cypress doesn't have binaries for that arch (and it tried `ia32`, although `armhf` also doesn't work):
```
URL: https://download.cypress.io/desktop/4.5.0?platform=linux&arch=ia32
Error: Failed downloading the Cypress binary.
Response code: 404
Response message: Not Found
```
I don't know if that is fixable.

I don't know how you guys build these snaps, if using launchpad or manually, but I added the `architctures` key to `snapcraft.yaml`.