### PR TITLE
Use core20, update grafana 7.2.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
     source-type: git
     source: https://github.com/grafana/grafana.git
     source-tag: v${SNAPCRAFT_PROJECT_VERSION}
-    nodejs-version: '12.18.0'
+    npm-node-version: '12.18.3'
     build-packages: [python2-minimal,python2-dev]
     override-build: |
       set -x

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
     stage-packages: [libfontconfig1, libfreetype6]
     override-build: |
         snapcraftctl build
-        mkdir ${SNAPCRAFT_PART_INSTALL}/bin ${SNAPCRAFT_PART_INSTALL}/conf
+        mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin ${SNAPCRAFT_PART_INSTALL}/conf
         cd ${SNAPCRAFT_PART_BUILD}
         GO111MODULE=on go run build.go setup
         GO111MODULE=on go run build.go build

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
         cp -p ${SNAPCRAFT_PART_BUILD}/bin/*/grafana-server \
           ${SNAPCRAFT_PART_BUILD}/bin/*/grafana-cli \
           ${SNAPCRAFT_PART_INSTALL}/bin/
-        cp -p ${SNAPCRAFT_PART_BUILD}/conf/defaults.ini ${SNAPCRAFT_PART_INSTALL}/conf/
+        cp -p -r ${SNAPCRAFT_PART_BUILD}/conf/* ${SNAPCRAFT_PART_INSTALL}/conf/
   grafana-ui:
     after: [grafana]
     plugin: npm

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -38,6 +38,7 @@ parts:
     build-packages: [build-essential, g++]
     stage-packages: [libfontconfig1, libfreetype6]
     override-build: |
+        set -x
         snapcraftctl build
         mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin ${SNAPCRAFT_PART_INSTALL}/conf
         cd ${SNAPCRAFT_PART_BUILD}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: grafana
 version: 7.0.5
 summary: feature rich metrics dashboard and graph editor
-base: core18
+base: core20
 description: |
   Grafana is a feature rich metrics dashboard and graph editor for Cloudwatch,
   Elasticsearch, Graphite, InfluxDB, OpenTSB, Prometheus, and Hosted Metrics.
@@ -35,10 +35,10 @@ parts:
     source: https://github.com/grafana/grafana.git
     source-tag: v${SNAPCRAFT_PROJECT_VERSION}
     source-depth: 1
-    go-importpath: github.com/grafana/grafana
     build-packages: [build-essential, g++]
     stage-packages: [libfontconfig1, libfreetype6]
     override-build: |
+        snapcraftctl build
         mkdir ${SNAPCRAFT_PART_INSTALL}/bin ${SNAPCRAFT_PART_INSTALL}/conf
         cd ${SNAPCRAFT_PART_BUILD}
         GO111MODULE=on go run build.go setup
@@ -49,16 +49,22 @@ parts:
         cp -p ${SNAPCRAFT_PART_BUILD}/conf/defaults.ini ${SNAPCRAFT_PART_INSTALL}/conf/
   grafana-ui:
     after: [grafana]
-    plugin: nodejs
+    plugin: npm
     source-type: git
     source: https://github.com/grafana/grafana.git
     source-tag: v${SNAPCRAFT_PROJECT_VERSION}
     nodejs-version: '12.18.0'
-    nodejs-package-manager: yarn
-    build-packages: [python-minimal,python-dev]
+    build-packages: [python2-minimal,python2-dev]
     override-build: |
+      set -x
+      # https://forum.snapcraft.io/t/issue-with-nodejs-plugin-when-using-base-keyword/11109/8
+      echo "unsafe-perm = true" > ~/.npmrc
+      snapcraftctl build
       export PYTHON=/usr/bin/python2
-      export PATH=${SNAPCRAFT_PART_BUILD}/../npm/bin:$PATH
+      # XXX check if needed
+      PATH="$PATH:$SNAPCRAFT_PART_BUILD/node_modules/.bin:$SNAPCRAFT_PART_INSTALL/bin"
+      NODE_ENV="production"
+      npm install -g --prefix $SNAPCRAFT_PART_INSTALL yarn
       yarn install --pure-lockfile --no-progress
       ${SNAPCRAFT_PART_BUILD}/node_modules/.bin/grunt build
       cp -rf public ${SNAPCRAFT_PART_INSTALL}/public

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 7.0.5
+version: 7.2.0
 summary: feature rich metrics dashboard and graph editor
 base: core20
 description: |


### PR DESCRIPTION
This branch does two things:
- switch to snap core 20
- update grafana to 7.2.0

I'm also now copying all the grafana config files, and not just `defaults.ini`, to mimic what upstream does (there is an extra ldap.toml file).

I think some of the PATH manipulations might not be necessary anymore. This snap takes a while to build, so I didn't fully vet that yet.