### PR TITLE
Update grafana to version 7.4.1 (and adjust the build procedures)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
     source-type: git
     source: https://github.com/grafana/grafana.git
     source-tag: v${SNAPCRAFT_PROJECT_VERSION}
-    npm-node-version: '12.18.3'
+    npm-node-version: '14.15.5'
     build-packages: [python2-minimal,python2-dev]
     override-build: |
       set -x

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -67,6 +67,6 @@ parts:
       NODE_ENV="production"
       npm install -g --prefix $SNAPCRAFT_PART_INSTALL yarn
       yarn install --pure-lockfile --no-progress
-      ${SNAPCRAFT_PART_BUILD}/node_modules/.bin/grunt build
+      yarn build
       cp -rf public ${SNAPCRAFT_PART_INSTALL}/public
       cp -rf tools ${SNAPCRAFT_PART_INSTALL}/tools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 7.2.0
+version: 7.4.1
 summary: feature rich metrics dashboard and graph editor
 base: core20
 description: |


### PR DESCRIPTION
Hi,

This series of commits update grafana to version 7.4.1 (latest one, at the time of this writing), bump `npm-node-version`, and call `yarn build` instead of `grunt build`, according to https://github.com/grafana/grafana/commit/2d49d3f5b23a3f4c35d7b96c2d1451dc5012ebb0#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557

I built this locally using `snapcraft build --use-lxd` and it succeeded.  Thanks!